### PR TITLE
add coverage

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -18,6 +18,7 @@
   - Struct tags
   - Test
   - Show lines that escape to heap
+  - Show uncovered lines
 
 ## Installation
 

--- a/conf/go.sublime-commands
+++ b/conf/go.sublime-commands
@@ -4,6 +4,14 @@
     "command": "go_test"
   },
   {
+    "caption": "Go: coverage",
+    "command": "go_coverage"
+  },
+  {
+    "caption": "Go: remove coverage",
+    "command": "go_remove_coverage"
+  },
+  {
     "caption": "Go: source",
     "command": "go_source"
   },

--- a/go/commands.py
+++ b/go/commands.py
@@ -2,6 +2,7 @@
 import sublime
 import sublime_plugin
 
+from . import coverage
 from . import spinner
 from . import buffer
 from . import escape
@@ -126,6 +127,34 @@ class GoTestCommand(sublime_plugin.TextCommand):
 
   def is_enabled(self, event=None):
     return buffer.is_go(self.view)
+
+class GoCoverageCommand(sublime_plugin.TextCommand):
+  locked = False
+
+  def run(self, edit):
+    if not self.locked:
+      self.lock()
+      p = coverage.run(self.view)
+      p.then(lambda _: self.unlock())
+
+  def lock(self):
+    self.locked = True
+    spinner.add(self.view, 'coverage')
+
+  def unlock(self):
+    self.locked = False
+    spinner.remove(self.view, 'coverage')
+
+  def is_enabled(self, event=None):
+    return buffer.is_go(self.view)
+
+class GoRemoveCoverageCommand(sublime_plugin.TextCommand):
+  def run(self, edit):
+    coverage.remove(self.view)
+
+  def is_enabled(self, event=None):
+    regions = self.view.get_regions('go.coverage')
+    return len(regions) > 0
 
 class GoAddTagsCommand(sublime_plugin.TextCommand):
   def run(self, edit, **args):

--- a/go/coverage.py
+++ b/go/coverage.py
@@ -1,0 +1,76 @@
+
+from tempfile import NamedTemporaryFile
+from . import decorators
+from . import buffer
+from . import exec
+from . import log
+import sublime
+
+@decorators.thread
+@decorators.trace
+def run(view):
+  remove(view)
+
+  pkg = buffer.package(view)
+  file = buffer.filename(view)
+  name = tmp()
+  args = ['test', '--cover', '--coverprofile', name, '.']
+  cmd = exec.Command('go', args=args, cwd=pkg)
+  res = cmd.run()
+
+  if res.code != 0:
+    return
+
+  mode = True
+  report = []
+  regions = []
+  lines = 0
+
+  with open(name) as f:
+    for line in f.readlines():
+      if not mode:
+        item = parse(line)
+        if item['count'] == 0:
+          report.append(item)
+      mode = False
+
+  for item in report:
+    if item['file'].endswith(file):
+      for line in item['range']:
+        point = view.text_point(line, 0)
+        region = view.line(point)
+        regions.append(region)
+        lines += 1
+
+  log.debug('cover: add {} regions {} uncovered lines', len(regions), lines)
+  set_temporary_status(view, 'go ∙ {} uncovered lines'.format(lines))
+  view.add_regions('go.coverage', regions, 'error', 'dot',
+    sublime.HIDDEN
+  )
+
+def remove(view):
+  view.erase_status('go.coverage')
+  view.erase_regions('go.coverage')
+
+def tmp():
+  f = NamedTemporaryFile()
+  f.close()
+  return f.name
+
+def parse(line):
+  parts = line.split(':')
+  file = parts[0]
+  meta = parts[1].split(' ')
+  ranges = meta[0].split(',')
+  begin = int(ranges[0].split('.')[0])
+  end = int(ranges[1].split('.')[0])
+  return dict(
+    file=file,
+    range=[n for n in range(begin, end)],
+    stmts=int(meta[1]),
+    count=int(meta[2])
+  )
+
+def set_temporary_status(view, text):
+  view.set_status('go.coverage', text)
+  sublime.set_timeout(lambda: view.erase_status('go.coverage'), 5e3)

--- a/go/listeners.py
+++ b/go/listeners.py
@@ -1,4 +1,5 @@
 
+from . import coverage
 from . import errors
 from . import buffer
 from . import gocode
@@ -13,14 +14,19 @@ class Listener(sublime_plugin.ViewEventListener):
     self.view = view
 
   def on_pre_save(self):
-    self.view.run_command("go_fmt")
+    self.run('go_fmt')
 
   def on_post_save_async(self):
-    self.view.run_command("go_vet")
-    self.view.run_command("go_lint")
+    self.run('go_vet')
+    self.run('go_lint')
+
+  def run(self, command):
+    if self.view.is_dirty():
+      self.view.run_command(command)
 
   def on_modified_async(self):
     errors.remove_all()
+    coverage.remove(self.view)
 
   def on_query_completions(self, prefix, points):
     if buffer.is_go(self.view):


### PR DESCRIPTION
When running the command, if there are any non-covered lines in the current view
a tiny circle with a scope name "error" shows up next to uncovered lines.

When the view changes, the inline circles will dissapear.
There is also a "go_remove_coverage" command that will only show up when the current
view has any non-covered lines.

Closes #5

![coverage](https://user-images.githubusercontent.com/1661587/63640535-35bf9a00-c6aa-11e9-9d1b-c1f1ec946ba7.gif)
