### PR TITLE
Run go-vet on a package, not on a directory

### DIFF
--- a/go/lint.py
+++ b/go/lint.py
@@ -4,6 +4,7 @@ from . import buffer
 from . import errors
 from . import exec
 from . import log
+import os
 import os.path as path
 import string
 import sublime
@@ -107,12 +108,13 @@ class Error():
     return self.__str__()
 
   @staticmethod
-  def parse(line, filename, tool):
+  def parse(line, filepath, tool):
     """
     Parse the given line and return an error.
 
     If an invalid line is given, None is returned.
     """
+    (root, cwd, filename) = filepath
 
     if line.startswith('vet:'):
       line = line[len('vet:'):]
@@ -124,8 +126,11 @@ class Error():
 
       if line.find('<standard input>') != -1:
         file = filename
-      elif file.startswith('./'):
-        file = file[2:]
+      elif file.startswith('.' + path.sep):
+        if path.join(cwd, file[2:]) == path.join(root, filename):
+          file = filename
+        else:
+          file = file[2:]
 
       if not parts[1].isdigit():
         row = int(parts[0])

--- a/go/vet.py
+++ b/go/vet.py
@@ -34,6 +34,6 @@ def run(view, edit):
   res = cmd.run()
 
   if res.code != 0:
-    errs = lint.parse(res.stderr, file, "vet")
+    errs = lint.parse(res.stderr, (root, cwd, file), "vet")
     log.debug('vet: {}', errs)
     errors.update("vet", view, errs)

--- a/go/vet.py
+++ b/go/vet.py
@@ -21,12 +21,16 @@ def run(view, edit):
   file = buffer.filename(view)
   pkg = buffer.package(view)
 
-  # When sublime is opened with `$ subl main.go`
   if len(view.window().folders()) == 0:
-    pkg = file
+    # When sublime is opened with `$ subl main.go`
+    target = file
+    cwd = root
+  else:
+    target = './...'
+    cwd = pkg
 
-  args = ["vet"] + ["--" + a for a in conf.vet_analyzers()] + [pkg]
-  cmd = exec.Command("go", args=args, cwd=root)
+  args = ["vet"] + ["--" + a for a in conf.vet_analyzers()] + [target]
+  cmd = exec.Command("go", args=args, cwd=cwd)
   res = cmd.run()
 
   if res.code != 0:


### PR DESCRIPTION
This PR is related to the issue found in #19.

The `go-vet` will use `./...` instead of absolute path to package directory. Thanks to such solution, there is not a problem if a package consist a `go.mod`, is in the `GOPATH` or is just piece of few `.go` files spread on disk. 

I was inspired by the `vscode-go` code - https://github.com/microsoft/vscode-go/blob/61b612e60346c663368e173150d1248610bebbc7/src/goVet.ts#L92 