### PR TITLE
Fix regression made in #24

### DIFF
--- a/go/escape.py
+++ b/go/escape.py
@@ -14,13 +14,14 @@ def run(view, edit):
   errors.remove("escape", view)
 
   args = ['build', '--gcflags=-m', '.']
+  root = buffer.root(view)
   pkg = buffer.package(view)
   cmd = exec.Command("go", args=args, cwd=pkg)
   res = cmd.run()
 
   if res.code == 0:
     file = buffer.filename(view)
-    errs = lint.parse(res.stderr, file, "escape")
+    errs = lint.parse(res.stderr, (root, pkg, file), "escape")
     errs = filter(errs, file, "escapes to heap")
     errors.update("escape", view, errs)
 

--- a/go/fmt.py
+++ b/go/fmt.py
@@ -16,6 +16,7 @@ def run(view, edit):
   pos = view.viewport_position()
   src = buffer.text(view)
   args = ["-e", "-srcdir", path.dirname(file)]
+  root = buffer.root(view)
   pkg = buffer.package(view)
   cmd = exec.Command("goimports", args=args, stdin=src, cwd=pkg)
   res = cmd.run()
@@ -24,5 +25,5 @@ def run(view, edit):
     buffer.replace(view, edit, res.stdout)
     return
 
-  errs = lint.parse(res.stderr, file, "fmt")
+  errs = lint.parse(res.stderr, (root, pkg, file), "fmt")
   errors.update("fmt", view, errs)


### PR DESCRIPTION
The change in #24 has made new requirements for parameters for `lint.parse` to provide them as a tuple of `(root, cwd, file)`.