### PR TITLE
add settings

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -10,7 +10,7 @@ jobs:
       max-parallel: 4
       matrix:
         python-version: [3.5.9, 3.6.10]
-        go-version: [1.12, 1.13]
+        go-version: [1.13, 1.14]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.5.7, 3.6.9]
+        python-version: [3.5.9, 3.6.10]
         go-version: [1.12, 1.13]
 
     steps:

--- a/conf/Golang.sublime-settings
+++ b/conf/Golang.sublime-settings
@@ -1,4 +1,16 @@
 {
+  // Root is the path to Go's bins.
+  //
+  // Typically Go's root is in your $PATH and if you're launching
+  // ST from the CLI it will pick up your $PATH and go(1) will be
+  // available for the plugin automatically.
+  //
+  // If you're launching ST in some other way, it might not pick
+  // up your login's shell $PATH and so go(1) will not be available.
+  //
+  // Example: "/usr/local/go/bin"
+  "root": null,
+
   // Vet specific configuration.
   //
   // Allows you to configure vet command line arguments.

--- a/conf/Main.sublime-menu
+++ b/conf/Main.sublime-menu
@@ -1,0 +1,25 @@
+[
+  {
+    "id": "preferences",
+    "children": [
+      {
+        "id": "package-settings",
+        "children": [
+          {
+            "caption": "Golang",
+            "children": [
+              {
+                "caption": "Settings",
+                "command": "edit_settings",
+                "args": {
+                  "base_file": "${packages}/Golang/Golang.sublime-settings",
+                  "default": "// Any settings in this file overrides the default ones\n{\n\t$0\n}\n"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/go/commands.py
+++ b/go/commands.py
@@ -17,8 +17,8 @@ from . import vet
 class GoSettingsCommand(sublime_plugin.TextCommand):
   def run(self, edit):
     sublime.run_command("edit_settings", {
-      'base_file': '${packages}/Golang/Golang.sublime-settings',
-      'default': '{\n  // Configure Golang plugin\n  $0\n}'
+      'base_file': "${packages}/Golang/Golang.sublime-settings",
+      'default': "// Any settings in this file overrides the default ones\n{\n\t$0\n}\n",
     })
 
 class GoFmtCommand(sublime_plugin.TextCommand):

--- a/go/conf.py
+++ b/go/conf.py
@@ -6,3 +6,8 @@ def vet_analyzers():
   settings = load_settings('Golang.sublime-settings')
   vet = settings.get('vet', {})
   return vet.get('analyzers', [])
+
+def root():
+  settings = load_settings("Golang.sublime-settings")
+  return settings.get("root", "")
+

--- a/go/exec.py
+++ b/go/exec.py
@@ -1,10 +1,13 @@
 
 import platform
-from subprocess import Popen, PIPE, STARTUPINFO, STARTF_USESHOWWINDOW
+from subprocess import Popen, PIPE
 from os import (environ, path)
 from . import decorators
 from . import buffer
 from . import log
+
+if platform.system() == "Windows":
+  from subprocess import STARTUPINFO, STARTF_USESHOWWINDOW
 
 class Command():
   """

--- a/go/exec.py
+++ b/go/exec.py
@@ -4,6 +4,7 @@ from subprocess import Popen, PIPE
 from os import (environ, path)
 from . import decorators
 from . import buffer
+from . import conf
 from . import log
 
 if platform.system() == "Windows":
@@ -78,7 +79,13 @@ def goenv(cwd, timeout=2):
   goenv returns the go environment based on cwd.
   """
   log.debug("exec: getting go env")
-  proc = Popen(["go", "env"], stdout=PIPE, cwd=cwd)
+  root = conf.root()
+  bin = "go"
+
+  if root != None:
+    bin = path.join(root, bin)
+
+  proc = Popen([bin, "env"], stdout=PIPE, cwd=cwd)
   out, _ = proc.communicate(timeout=timeout)
   out = out.decode('UTF-8')
   env = {}

--- a/tests/sublime/__init__.py
+++ b/tests/sublime/__init__.py
@@ -6,3 +6,6 @@ class Region():
 
 def PhantomSet(set):
   pass
+
+def load_settings(name):
+  return {}


### PR DESCRIPTION
- Add `"vet.analyzers"` option to pick vet's analyzers
- Add `"root"` option to set Go's root (like "/usr/local/go/bin")
- Add `Go: settings` command to configure settings easily.
- Add `Golang` menu to complete ^.

This should solve #27, #11 because they will be able to simply add the go path to settings, like:

```json
{
  "root": "/usr/local/bin"
}
```

The plugin will then invoke `$ go env` to ensure that all of the other tooling would work as well, such as `gocode(1)`, `golint(1)` etc..