### PR TITLE
Fixes for errors and support single files.

### DIFF
--- a/go/errors.py
+++ b/go/errors.py
@@ -5,26 +5,20 @@ from . import buffer
 state = {}
 
 def update(key, view, errors):
-  """
-  Update updates the set of shown errors.
-
-  The method shos a given list of errors on the given
-  view, keyed by `key`, each tool uses a different key.
-  """
-  set = PhantomSet(view, key)
+  phantoms = PhantomSet(view, key)
+  dedupe = {}
   all = []
 
   for err in errors:
     if buffer.filename(view) == err.file:
+      if err.line not in dedupe:
         all.append(err.to_phantom(view))
+        dedupe[err.line] = True
 
-  set.update(all)
-  state[id(key, view.id())] = set
+  phantoms.update(all)
+  state[id(key, view.id())] = phantoms
 
 def remove(key, view):
-  """
-  Remove removes all errors from view of key.
-  """
   key = id(key, view.id())
   if key in state:
     state[key].update([])

--- a/go/exec.py
+++ b/go/exec.py
@@ -55,7 +55,7 @@ class Command():
     )
 
     stdout, stderr = proc.communicate(input=stdin, timeout=timeout)
-    log.debug("$ {} {} => {}", self.cmd, ' '.join(self.args), proc.returncode)
+    log.debug("$ {} {} => {} (cwd={})", self.cmd, ' '.join(self.args), proc.returncode, self.cwd)
 
     return Result(
       code=proc.returncode,

--- a/go/lint.py
+++ b/go/lint.py
@@ -96,17 +96,6 @@ class Error():
       'msg': msg,
     }
 
-  def __str__(self):
-    return ':'.join([
-      self.tool,
-      self.file,
-      str(self.line),
-      str(self.col),
-    ]) + " " + self.msg
-
-  def __repr__(self):
-    return self.__str__()
-
   @staticmethod
   def parse(line, filepath, tool):
     """


### PR DESCRIPTION
The PR fixes two issues.

__Closes #31__

Fixes an issue where if you open a single file like `$ s main.go` the plugin would not run vet correctly.

__Closes #28__

Fixes an issue where if there's a lot of errors for the same line (coming from vet, lint etc..) the plugin would try to show them all, on the same line.