### PR TITLE
Add staticcheck

### DIFF
--- a/conf/Golang.sublime-commands
+++ b/conf/Golang.sublime-commands
@@ -42,5 +42,9 @@
   {
     "caption": "Go: clear tags",
     "command": "go_clear_tags"
+  },
+  {
+    "caption": "Go: static check",
+    "command": "go_static_check"
   }
 ]

--- a/conf/Golang.sublime-settings
+++ b/conf/Golang.sublime-settings
@@ -16,5 +16,27 @@
   // Allows you to configure vet command line arguments.
   "vet": {
   	"analyzers": []
+  },
+
+  // Staticcheck(1) specific configuration.
+  //
+  // You have to have staticcheck(1) installed:
+  //
+  //   $ go get honnef.co/go/tools/...
+  //
+  "staticcheck": {
+    // An array of check codes to run on post-save.
+    //
+    // When the array is empty, no static checks are run at all.
+    // You can see the full list of available checks at:
+    //
+    // https://staticcheck.io/docs/checks
+    //
+    // Some handy checks to enable:
+    //
+    //   - U1000   Unused code.
+    //   - SA1029  Inappropriate key in call to context.WithValue
+    //
+    "checks": []
   }
 }

--- a/go/commands.py
+++ b/go/commands.py
@@ -13,6 +13,7 @@ from . import lint
 from . import log
 from . import fmt
 from . import vet
+from . import staticcheck
 
 class GoSettingsCommand(sublime_plugin.TextCommand):
   def run(self, edit):
@@ -44,6 +45,26 @@ class GoVetCommand(sublime_plugin.TextCommand):
   def unlock(self):
     self.locked = False
     spinner.remove(self.view, 'vet')
+
+  def is_enabled(self):
+    return buffer.is_go(self.view)
+
+class GoStaticCheckCommand(sublime_plugin.TextCommand):
+  locked = False
+
+  def run(self, edit):
+    if not self.locked:
+      self.lock()
+      p = staticcheck.run(self.view, edit)
+      p.then(lambda _: self.unlock())
+
+  def lock(self):
+    self.locked = True
+    spinner.add(self.view, 'staticcheck')
+
+  def unlock(self):
+    self.locked = False
+    spinner.remove(self.view, 'staticcheck')
 
   def is_enabled(self):
     return buffer.is_go(self.view)

--- a/go/conf.py
+++ b/go/conf.py
@@ -7,6 +7,11 @@ def vet_analyzers():
   vet = settings.get('vet', {})
   return vet.get('analyzers', [])
 
+def static_checks():
+  settings = load_settings('Golang.sublime-settings')
+  sc = settings.get('staticcheck', {})
+  return sc.get('checks', [])
+
 def root():
   settings = load_settings("Golang.sublime-settings")
   return settings.get("root", "")

--- a/go/listeners.py
+++ b/go/listeners.py
@@ -20,6 +20,7 @@ class Listener(sublime_plugin.ViewEventListener):
   def on_post_save_async(self):
     self.view.run_command('go_vet')
     self.view.run_command('go_lint')
+    self.view.run_command('go_static_check')
 
   def on_modified_async(self):
     errors.remove_all()

--- a/go/staticcheck.py
+++ b/go/staticcheck.py
@@ -1,0 +1,37 @@
+
+from . import decorators
+from . import buffer
+from . import errors
+from . import conf
+from . import lint
+from . import exec
+from . import log
+import os.path as path
+import sublime
+import sys
+
+@decorators.thread
+@decorators.trace
+def run(view, edit):
+  """
+  Run runs staticcheck(1) on the given view.
+  """
+  errors.remove("vet", view)
+  root = buffer.root(view)
+  file = buffer.filename(view)
+  pkg = buffer.package(view)
+  checks = conf.static_checks()
+
+  if len(checks) == 0:
+    log.debug('staticcheck: no checks to run')
+    return
+
+  all = ','.join(checks)
+  args = ['--checks', all, pkg]
+  cmd = exec.Command("staticcheck", args=args, cwd=root)
+  res = cmd.run()
+
+  if res.code != 0:
+    errs = lint.parse(res.stdout, (root, root, file), "staticcheck")
+    log.debug('staticcheck: {}', errs)
+    errors.update("staticcheck", view, errs)

--- a/scripts/dev.py
+++ b/scripts/dev.py
@@ -19,7 +19,8 @@ submodules = [
 	'spinner',
 	'tags',
 	'test',
-	'vet'
+	'vet',
+	'staticcheck'
 ]
 
 def plugin_loaded():


### PR DESCRIPTION
There's a new settings for it, `static_check.checks[]`, by default there are no checks you can add them yourself.

Here's an example check that shows unused code (`U1000`):

<img width="463" alt="Screen Shot 2020-04-25 at 19 03 20" src="https://user-images.githubusercontent.com/1661587/80284593-2f495c80-8728-11ea-8f44-42fdb47a68df.png">

The settings I've used:

```json
 {
  "staticcheck": {
    "checks": [
      "U1000"
    ]
  }
```

Closes #18